### PR TITLE
Add command line parameter to select profile (tenancy) from config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository are example Python script to work with the Oracle Cloud Infrastr
 It used the Oracle Python SDK: https://oracle-cloud-infrastructure-python-sdk.readthedocs.io/en/latest/
 
 Samples scripts:
-- List instances: This creates a CSV file with all Instances and details, across all compartments and regions, including predefined tags
+- List instances: This creates a CSV file with all Instances and details, across all compartments and regions, including predefined tags  
+Parameter: \<profile\> selects the named tenancy from the config file
 
 ![alt text](https://raw.githubusercontent.com/AnykeyNL/OCI-Python/master/example.png)

--- a/config.example
+++ b/config.example
@@ -4,3 +4,10 @@ fingerprint=f7:82:7e:65:09:82:2e:2c:49:73:85:c1:28:43:01:6c
 key_file=C:\oci\private_ssh_keyfile.pem
 tenancy=ocid1.tenancy.oc1..xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 region=eu-frankfurt-1
+
+[tenancy2]
+user=ocid1.user.oc1..yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+fingerprint=f7:82:7e:65:09:82:2e:2c:49:73:85:c1:28:43:01:6c
+key_file=C:\oci\private_ssh_keyfile.pem
+tenancy=ocid1.tenancy.oc1..yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+region=eu-frankfurt-1

--- a/list_instances.py
+++ b/list_instances.py
@@ -18,6 +18,7 @@ import oci
 import json
 import shapes
 import logging
+import sys
 
 # Script configuation ###################################################################################
 
@@ -167,17 +168,24 @@ def DisplayInstances(instances, compartmentName, instancetype, regionname):
     report.write(line + EndLine)    
 
 #Do only once
+
+# Get profile from command line
+if len(sys.argv) == 2:
+  profile = sys.argv[1]
+else:
+  profile='DEFAULT'
+
 report = open(ReportFile,'w')
 
 customertags = []
 header = "Name,State,Service,Licensed,Version,OS,Shape,OCPU,MEMORY,SSD TB,Compartment,AD,PrivateIP,PublicIP".replace(",", FieldSeperator)
-config = oci.config.from_file(configfile)
+config = oci.config.from_file(configfile, profile_name=profile)
 
 identity = oci.identity.IdentityClient(config)
 user = identity.get_user(config["user"]).data
 RootCompartmentID = user.compartment_id
   
-print ("Logged in as: {} @ {}".format(user.description, config["region"]))
+print ("Logged in as: {} @ {}  (Profile={})".format(user.description, config["region"], profile))
 print ("Querying Enabled Regions:")
 
 response = identity.list_region_subscriptions(config["tenancy"])
@@ -221,7 +229,7 @@ report.write(header+EndLine)
 #Retrieve all instances for each config file (regions)
 
 for region in regions:
-  config = oci.config.from_file(configfile)
+  config = oci.config.from_file(configfile, profile_name=profile)
   config["region"] = region.region_name
 
   identity = oci.identity.IdentityClient(config)


### PR DESCRIPTION
Hi Richard, As mentioned, my first mod to add an optional command line parameter to select a profile from the config file.  Very useful when reporting across multiple tenancies.